### PR TITLE
Use Kotlin release `2.0.20`

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.20-RC2" />
+    <option name="version" value="2.0.20" />
   </component>
 </project>

--- a/docker/build.gradle.kts
+++ b/docker/build.gradle.kts
@@ -31,7 +31,7 @@ gradlePlugin {
 }
 
 dependencies {
-	compileOnly(kotlin("gradle-plugin", version = "2.0.20-Beta1"))
+	compileOnly(kotlin("gradle-plugin", version = "2.0.20"))
 
 	detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.6")
 	detektPlugins("io.gitlab.arturbosch.detekt:detekt-rules-libraries:1.23.6")

--- a/kordex/build.gradle.kts
+++ b/kordex/build.gradle.kts
@@ -31,7 +31,7 @@ gradlePlugin {
 }
 
 dependencies {
-	compileOnly(kotlin("gradle-plugin", version = "2.0.20-Beta1"))
+	compileOnly(kotlin("gradle-plugin", version = "2.0.20"))
 
 	detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.6")
 	detektPlugins("io.gitlab.arturbosch.detekt:detekt-rules-libraries:1.23.6")

--- a/testModule/settings.gradle.kts
+++ b/testModule/settings.gradle.kts
@@ -2,9 +2,9 @@ pluginManagement {
 	plugins {
 		val pluginVersion = "1.4.1"
 
-		kotlin("jvm") version "2.0.20-RC2"
+		kotlin("jvm") version "2.0.20"
 
-		id("com.google.devtools.ksp") version "2.0.20-RC2-1.0.24"
+		id("com.google.devtools.ksp") version "2.0.20-1.0.24"
 		id("dev.kordex.gradle.docker") version pluginVersion
 		id("dev.kordex.gradle.kordex") version pluginVersion
 	}


### PR DESCRIPTION
Use Kotlin stable release `2.0.20` for modules:
- docker
- kordex
- testModule

Also use `2.0.20-1.0.24` for Google KSP to pair with updated Kotlin stable release.